### PR TITLE
HTTP 1.1 Basic Authentication Support

### DIFF
--- a/src/WebSocketClient.ts
+++ b/src/WebSocketClient.ts
@@ -114,6 +114,7 @@ class WebSocketClient {
       key: wsConfig.key as any,
       cert: wsConfig.cert as any,
       ca: wsConfig.ca as any,
+      headers: wsConfig.headers,
     });
 
     const connectionId = 0;

--- a/src/WebSocketConnection.ts
+++ b/src/WebSocketConnection.ts
@@ -725,7 +725,7 @@ class WebSocketConnection {
         const ca = utils.collectPEMs(this.config.ca).map(utils.pemToDER);
         try {
           if (this.config.verifyPeer && this.config.verifyCallback != null) {
-            await this.config.verifyCallback?.(peerCertChain, ca);
+            await this.config.verifyCallback?.(peerCertChain, ca, request.headers);
           }
           this._localHost = request.connection.localAddress as Host;
           this._localPort = request.connection.localPort as Port;

--- a/src/WebSocketConnection.ts
+++ b/src/WebSocketConnection.ts
@@ -725,7 +725,11 @@ class WebSocketConnection {
         const ca = utils.collectPEMs(this.config.ca).map(utils.pemToDER);
         try {
           if (this.config.verifyPeer && this.config.verifyCallback != null) {
-            await this.config.verifyCallback?.(peerCertChain, ca, request.headers);
+            await this.config.verifyCallback?.(
+              peerCertChain,
+              ca,
+              request.headers,
+            );
           }
           this._localHost = request.connection.localAddress as Host;
           this._localPort = request.connection.localPort as Port;

--- a/src/WebSocketServer.ts
+++ b/src/WebSocketServer.ts
@@ -312,6 +312,14 @@ class WebSocketServer {
       ...serverDefault,
       ...config,
     };
+    // Config header names need to be set to lowercase
+    if (this.config.headers != null) {
+      const originalHeaders = this.config.headers;
+      this.config.headers = {};
+      for (const [headerName, value] of Object.entries(originalHeaders)) {
+        this.config.headers[headerName.toLowerCase()] = value;
+      }
+    }
     this.resolveHostname = resolveHostname;
 
     this.connectTimeoutTime = connectTimeoutTime;

--- a/src/WebSocketServer.ts
+++ b/src/WebSocketServer.ts
@@ -379,7 +379,7 @@ class WebSocketServer {
           const peerCertChain = utils.toPeerCertChain(peerCert);
           const ca = utils.collectPEMs(this.config.ca).map(utils.pemToDER);
           try {
-            await this.config.verifyCallback(peerCertChain, ca);
+            await this.config.verifyCallback(peerCertChain, ca, info.req.headers);
             return done(true);
           } catch (e) {
             info.req.destroy(e);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { IncomingHttpHeaders } from "http";
+
 // Async
 
 /**
@@ -79,6 +81,7 @@ type ConnectionMetadata = {
 type TLSVerifyCallback = (
   certs: Array<Uint8Array>,
   ca: Array<Uint8Array>,
+  headers: IncomingHttpHeaders
 ) => PromiseLike<void>;
 
 type WebSocketConfig = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { IncomingHttpHeaders } from "http";
+import type { IncomingHttpHeaders } from 'http';
 
 // Async
 
@@ -81,7 +81,7 @@ type ConnectionMetadata = {
 type TLSVerifyCallback = (
   certs: Array<Uint8Array>,
   ca: Array<Uint8Array>,
-  headers: IncomingHttpHeaders
+  headers: IncomingHttpHeaders,
 ) => PromiseLike<void>;
 
 type WebSocketConfig = {
@@ -118,6 +118,12 @@ type WebSocketConfig = {
    * Currently multiple key and certificate chains is not supported.
    */
   cert?: string | Array<string> | Uint8Array | Array<Uint8Array>;
+
+  /**
+   * Headers that will be attached to the HTTP Upgrade Request/Response.
+   * This can be used for authentication purposes, or to provide metadata regarding the connection.
+   */
+  headers?: IncomingHttpHeaders;
 
   /**
    * Verify the other peer.


### PR DESCRIPTION
### Description
This PR allows users to process the HTTP headers of incoming connections in `verifyCallback` and provide headers in the `WebSocketConfig` to facilitate  HTTP 1.1 Basic Authentication.

Furthermore, the user is able to provide `headers` on the `config` parameter of both `WebSocketClient` and `WebSocketServer`.

### Issues Fixed
<!-- List all issues fixed by this PR. -->
* Fixes #29 

### Tasks
<!-- 
  List all tasks to be done by this PR.
  If a task is no longer required, add a strikethrough (including the checkbox):
  - ~~[ ] 3. ...~~ - being completed in #...
-->
- [x] 1. Pass headers into `TLSVerifyCallback`
- [x] 2. Allow user to pass headers into `config`

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
